### PR TITLE
fix: 3 deployment bugs — GitHub pack_id slash, local.toml not loaded, path display crash

### DIFF
--- a/src/scout/cli.py
+++ b/src/scout/cli.py
@@ -495,7 +495,7 @@ def discover(
             pack_id=pack_obj.frontmatter.pack_id,
             decision="packed",
         )
-        typer.echo(f"  ✓ {score.final_score:.1f}: {path.relative_to(c.project_root)}")
+        typer.echo(f"  ✓ {score.final_score:.1f}: {path.relative_to(c.project_root, walk_up=True)}")
         written += 1
 
     typer.echo(f"done: wrote {written} pack(s)")
@@ -530,7 +530,7 @@ def list_packs(
             continue
         for f in sorted(date_dir.iterdir()):
             if f.suffix == ".md":
-                typer.echo(str(f.relative_to(c.project_root)))
+                typer.echo(str(f.relative_to(c.project_root, walk_up=True)))
 
 
 @app.command()

--- a/src/scout/config.py
+++ b/src/scout/config.py
@@ -68,6 +68,11 @@ def load(toml_path: Path | None = None) -> Config:
     if toml_path.exists():
         raw = tomllib.loads(toml_path.read_text())
 
+    # Merge local overrides (gitignored; machine-specific settings like output_dir)
+    local_path = toml_path.with_name("scout.local.toml")
+    if local_path.exists():
+        raw.update(tomllib.loads(local_path.read_text()))
+
     return Config(
         project_root=root,
         output_dir=root / raw.get("output_dir", "output/packs"),

--- a/src/scout/harvest/packer.py
+++ b/src/scout/harvest/packer.py
@@ -22,7 +22,8 @@ from scout.utils.slug import slugify
 
 
 def build_pack_id(candidate: Candidate, *, today: datetime, suffix: str | None = None) -> str:
-    base = f"{candidate.source_platform.replace('_', '-')}-{today:%Y-%m-%d}-{candidate.external_id}"
+    safe_id = candidate.external_id.replace("/", "-")  # GitHub owner/repo → owner-repo
+    base = f"{candidate.source_platform.replace('_', '-')}-{today:%Y-%m-%d}-{safe_id}"
     return f"{base}-{suffix}" if suffix else base
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from scout.config import _load_dotenv
+from scout.config import _load_dotenv, load
 
 
 def test_dotenv_loads_keys(tmp_path: Path, monkeypatch):
@@ -23,3 +23,22 @@ def test_dotenv_does_not_override_existing(tmp_path: Path, monkeypatch):
 
 def test_dotenv_missing_file_is_silent(tmp_path: Path):
     _load_dotenv(tmp_path / "no_such_file")  # must not raise
+
+
+def test_local_toml_overrides_base(tmp_path: Path):
+    """scout.local.toml must be merged on top of scout.toml (regression #12)."""
+    base = tmp_path / "scout.toml"
+    base.write_text('score_threshold = 7.0\nmax_comments_per_pack = 5\n')
+    local = tmp_path / "scout.local.toml"
+    local.write_text('score_threshold = 6.0\n')
+    cfg = load(toml_path=base)
+    assert cfg.score_threshold == 6.0  # local wins
+    assert cfg.max_comments_per_pack == 5  # base preserved
+
+
+def test_local_toml_missing_is_silent(tmp_path: Path):
+    """load() must not raise when scout.local.toml doesn't exist."""
+    base = tmp_path / "scout.toml"
+    base.write_text('score_threshold = 7.5\n')
+    cfg = load(toml_path=base)
+    assert cfg.score_threshold == 7.5

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
 
-from scout.harvest.packer import assemble, to_markdown, write_pack
+from scout.harvest.packer import assemble, build_pack_id, to_markdown, write_pack
 from scout.models import Candidate, ControversySignal, ScoreResult
 
 
@@ -82,6 +83,44 @@ def test_assemble_without_score_marks_unsure(tmp_path: Path):
     assert "建议层级" in md
     assert "unsure" in md
     assert "（未生成）" in md  # no judgment_seed
+
+
+def _github_candidate() -> Candidate:
+    return Candidate(
+        source_platform="github",
+        external_id="mattpocock/skills",
+        primary_url="https://github.com/mattpocock/skills",
+        original_url="https://github.com/mattpocock/skills",
+        url_hash="hashgh1",
+        title="mattpocock/skills — Agent Skills for Real Engineers",
+        metrics={"github_stars": 1200, "github_stars_today": 340},
+    )
+
+
+def test_build_pack_id_github_slash_is_sanitized():
+    """GitHub owner/repo external_id must not produce a '/' in pack_id (regression #11)."""
+    cand = _github_candidate()
+    today = datetime(2026, 4, 27, tzinfo=UTC)
+    pack_id = build_pack_id(cand, today=today)
+    assert "/" not in pack_id
+    assert pack_id == "github-2026-04-27-mattpocock-skills"
+
+
+def test_write_pack_github_creates_flat_file(tmp_path: Path):
+    """write_pack must create a flat .md file, not a nested dir, for GitHub repos (regression #11)."""
+    pack = assemble(
+        _github_candidate(),
+        fulltext_md="# body",
+        fulltext_method="trafilatura",
+        fulltext_warnings=[],
+        comments_render="",
+        comments_count=0,
+        score=None,
+    )
+    path = write_pack(pack, output_dir=tmp_path)
+    assert path.exists(), f"pack file not created: {path}"
+    assert path.is_file()
+    assert "/" not in path.name
 
 
 def test_failed_fulltext_renders_warning(tmp_path: Path):


### PR DESCRIPTION
## 问题背景

首次部署到 HK Mac mini 时发现 `scout discover` 完全跑不通，通过 `logs/cron.log` 定位到三个独立 bug。

## 修复内容

### Bug 1 — GitHub Trending pack 写盘失败（closes #11）

**根因**：`external_id = "owner/repo"`（含 `/`）被原样拼入 `pack_id`，`write_pack` 用 `pack_id.split('-')[-1]` 取得 `"owner/repo"`，pathlib 把 `/` 解析为目录分隔符，中间目录从未创建 → `FileNotFoundError`。

**修复**：`packer.py:build_pack_id` 加一行 `safe_id = candidate.external_id.replace("/", "-")`。

### Bug 2 — `scout.local.toml` 静默忽略（closes #12）

**根因**：`config.load()` 只读 `scout.toml`，从未合并 `scout.local.toml`。部署机器上 `output_dir = "/Users/.../llmx-scout-packs/packs"` 完全不生效，output 落回默认 `output/packs`（scout 仓内），git delivery 不触发。

**修复**：`config.py:load()` 加载 `scout.toml` 后，若 `scout.local.toml` 存在则 merge。

### Bug 3 — `path.relative_to(project_root)` 崩溃（closes #13）

**根因**：`output_dir` 在 project root 外时，`cli.py` 的展示行调用 `path.relative_to(project_root)` 抛 `ValueError`，pack 虽已写盘但 discover 以 exit code 1 退出，delivery 不执行。

**修复**：改用 `relative_to(..., walk_up=True)`（Python 3.12+），跨目录展示相对路径。

## 测试

新增 4 条回归测试（`test_packer.py` × 2，`test_config.py` × 2），全套 75 个测试通过。

## 端到端验证

修复后在部署机器上真实运行 `scout discover --limit 20`：

```
✓ 7.0: ../llmx-scout-packs/packs/2026-04-27/...github-GitNexus.md
✓ 7.0: ../llmx-scout-packs/packs/2026-04-27/...reddit-1swpsv0.md
✓ 8.0: ../llmx-scout-packs/packs/2026-04-27/...reddit-1sw77p0.md
done: wrote 3 pack(s)
  ↑ pushed 838e2bf02571 (3 pack(s))
```

Pack 已 push 到 [`llmx-scout-packs`](https://github.com/LLM-X-Factorer/llmx-scout-packs)。

## Checklist

- [x] 3 bugs fixed, 3 issues closed (#11, #12, #13)
- [x] 75 tests pass (was 71)
- [x] End-to-end verified on deployment machine
- [x] Git delivery confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)